### PR TITLE
changed back to featherpad for startup menu entry

### DIFF
--- a/dot-fluxbox/menu-mx
+++ b/dot-fluxbox/menu-mx
@@ -40,7 +40,7 @@
             [exec] (Keys) {xdg-open ~/.fluxbox/keys}
             [exec] (Menu) {xdg-open ~/.fluxbox/menu-mx}
             [exec] (Overlay) {xdg-open ~/.fluxbox/overlay}
-            [exec] (Startup) {xdg-open ~/.fluxbox/startup}
+            [exec] (Startup) {featherpad ~/.fluxbox/startup}
             [exec] (Styles) {thunar ~/.fluxbox/styles/}
         [end]
         [submenu] (Keyboard)


### PR DESCRIPTION
xdg-open did not work with the startup file, which is a script. So I restored it to featherpad command.