### PR TITLE
Add 2 mxfb-quickshot shortcuts

### DIFF
--- a/mx/etc/skel/.fluxbox/keys
+++ b/mx/etc/skel/.fluxbox/keys
@@ -18,6 +18,8 @@
 
 # take a screen capture
 none Print :Exec mxfb-quickshot
+Shift Print :Exec mxfb-quickshot -r -png
+Mod1 Print :Exec mxfb-quickshot -u -png
 
 # open help
 Ctrl F1 :Exec mxfb-help


### PR DESCRIPTION
With [my recent addition](https://github.com/MX-Linux/mxfb-accessories/pull/50) in `mxfb-quickshot` script I'm adding  2 keyboard shortcuts.

`Shift + Print` to take a capture of the whole screen.
`Alt + Print` to take a capture of the current active window.  The previous PR must be merged in order to this shortcut work.

Is there a special reason for not changing `DESTDIR="${XDG_PICTURES_DIR}"` to `DESTDIR="${XDG_PICTURES_DIR}/Screenshots"` in the `mxfb-quickshot.conf` file by default?